### PR TITLE
Align Android package ID with Firebase config

### DIFF
--- a/app/<project>/build.gradle.kts
+++ b/app/<project>/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    namespace = "com.creativedeckfence.creativeopsportal"
+    namespace = "com.creativedeckfence.creativeops"
     compileSdk = 34
 
     defaultConfig {
-        applicationId = "com.creativedeckfence.creativeopsportal"
+        applicationId = "com.creativedeckfence.creativeops"
         minSdk = 24
         targetSdk = 34
         versionCode = 1


### PR DESCRIPTION
## Summary
- choose com.creativedeckfence.creativeops as the canonical Android package ID
- update the Android module configuration to use the canonical namespace and applicationId

## Testing
- gradle -p 'app/<project>' assembleDebug *(fails: project name '<project>' is invalid for Gradle projects)*

------
https://chatgpt.com/codex/tasks/task_e_68da67cded608324886ae3367ca2faa6